### PR TITLE
Fix dead link / Add available conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@
   - [conventional-changelog-angular/convention.md](https://github.com/conventional-changelog/conventional-changelog-angular/blob/master/convention.md)
   - [conventional-changelog-jquery/convention.md](https://github.com/conventional-changelog/conventional-changelog-jquery/blob/master/convention.md)
   - [conventional-changelog-ember/convention.md](https://github.com/conventional-changelog/conventional-changelog-ember/blob/master/convention.md)
-  - [conventional-changelog-jshint/convention.md
-  ](https://github.com/conventional-changelog/conventional-changelog-jshint/blob/master/convention.md)
+  - [conventional-changelog-jshint/convention.md](https://github.com/conventional-changelog/conventional-changelog-jshint/blob/master/convention.md)
   - [conventional-changelog-eslint/convention.md](https://github.com/conventional-changelog/conventional-changelog-eslint/blob/master/convention.md)
   - [conventional-changelog-atom/convention.md](https://github.com/conventional-changelog/conventional-changelog-atom/blob/master/convention.md)
 

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@
 - [コミットメッセージの書き方 - ククログ(2012-02-21)](http://www.clear-code.com/blog/2012/2/21.html)
 - [AngularJS Git Commit Message Conventions](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#)
   - [conventional-changelog-angular/convention.md](https://github.com/conventional-changelog/conventional-changelog-angular/blob/master/convention.md)
-  - [conventional-changelog-jquery/convention.md](https://github.com/conventional-changelog/conventional-changelog-jquery/blob/master/convention.md)
-  - [conventional-changelog-ember/convention.md](https://github.com/conventional-changelog/conventional-changelog-ember/blob/master/convention.md)
-  - [conventional-changelog-jshint/convention.md](https://github.com/conventional-changelog/conventional-changelog-jshint/blob/master/convention.md)
-  - [conventional-changelog-eslint/convention.md](https://github.com/conventional-changelog/conventional-changelog-eslint/blob/master/convention.md)
   - [conventional-changelog-atom/convention.md](https://github.com/conventional-changelog/conventional-changelog-atom/blob/master/convention.md)
+  - [conventional-changelog-ember/convention.md](https://github.com/conventional-changelog/conventional-changelog-ember/blob/master/convention.md)
+  - [conventional-changelog-eslint/convention.md](https://github.com/conventional-changelog/conventional-changelog-eslint/blob/master/convention.md)
+  - [conventional-changelog-jquery/convention.md](https://github.com/conventional-changelog/conventional-changelog-jquery/blob/master/convention.md)
+  - [conventional-changelog-jshint/convention.md](https://github.com/conventional-changelog/conventional-changelog-jshint/blob/master/convention.md)
 
 ## データベース
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,13 @@
 
 - [コミットメッセージの書き方 - ククログ(2012-02-21)](http://www.clear-code.com/blog/2012/2/21.html)
 - [AngularJS Git Commit Message Conventions](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#)
-    - [conventional-changelog/CONVENTIONS.md at master · ajoslin/conventional-changelog](https://github.com/ajoslin/conventional-changelog/blob/master/CONVENTIONS.md)
+  - [conventional-changelog-angular/convention.md](https://github.com/conventional-changelog/conventional-changelog-angular/blob/master/convention.md)
+  - [conventional-changelog-jquery/convention.md](https://github.com/conventional-changelog/conventional-changelog-jquery/blob/master/convention.md)
+  - [conventional-changelog-ember/convention.md](https://github.com/conventional-changelog/conventional-changelog-ember/blob/master/convention.md)
+  - [conventional-changelog-jshint/convention.md
+  ](https://github.com/conventional-changelog/conventional-changelog-jshint/blob/master/convention.md)
+  - [conventional-changelog-eslint/convention.md](https://github.com/conventional-changelog/conventional-changelog-eslint/blob/master/convention.md)
+  - [conventional-changelog-atom/convention.md](https://github.com/conventional-changelog/conventional-changelog-atom/blob/master/convention.md)
 
 ## データベース
 


### PR DESCRIPTION
`conventional-changelog/CONVENTIONS.md`は`angular`の規約なので、[conventional-changelog-angular](https://github.com/conventional-changelog/conventional-changelog-angular/blob/master/convention.md)に移動しました。

くわえて、`--preset`として`atom`, `codemirror`, `ember`, `eslint`, `express`, `jquery`, `jscs`, `jshint`が[conventional-changelog@ 1.1.0](https://github.com/conventional-changelog/conventional-changelog) / [conventional-github-releaser@1.1.2](https://github.com/conventional-changelog/conventional-github-releaser)で利用可能になっています。
上記オプションでドキュメントが用意されているものは、リンクとして追加しました。（`express`, `codemirror`は無いようです）
