### PR TITLE
Add GitHubコミットメッセージの文例が検索できるサービス

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@
 
 ## データベース
 
+- [commit-m: GitHubコミットメッセージの文例が検索できるサービス](http://commit-m.minamijoyo.com/)
+    - GitHubコミットメッセージの文例が検索できるサービス
 - [Commit Message Generator](http://whatthecommit.com/)
     - コミットメッセージをランダムで表示してくれるサービス
 - [GitHub Archive](https://www.githubarchive.org/)


### PR DESCRIPTION
[commit-m: GitHubコミットメッセージの文例が検索できるサービス](http://commit-m.minamijoyo.com/)を追加しました。

思い付く単語を入れて検索するだけで，それらの単語が使われているコミットメッセージが出てくるので使っていて便利に思い，追加させて頂きました。

追加した場所はデータベースにしましたが，もしも間違っていれば変更をお願いいたします。